### PR TITLE
Add favourite table with foreign key relationships

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -2,3 +2,27 @@
 CREATE DATABASE airbnb;
 -- work with airbnb database
 USE airbnb;
+
+
+-- ==============================================
+-- Table: favourite
+-- Stores records of properties that a user has marked as favourite.
+-- Each row links a user to a property via foreign keys.
+-- Only the two specified columns are present (requirement).
+-- ==============================================
+
+CREATE TABLE favourite (
+    property_id INT NOT NULL,
+    user_id INT NOT NULL,
+    CONSTRAINT pk_favourite PRIMARY KEY (property_id, user_id),
+    CONSTRAINT fk_favourite_property
+        FOREIGN KEY (property_id)
+        REFERENCES property(property_id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE,
+    CONSTRAINT fk_favourite_user
+        FOREIGN KEY (user_id)
+        REFERENCES user_account(user_id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+);


### PR DESCRIPTION
Adds the `favourite` table to link users with their favourite properties.

Highlights:
- Columns: property_id (INT), user_id (INT)
- Composite primary key (property_id, user_id) to disallow duplicates
- Foreign keys:
  - property_id → property(property_id) ON DELETE/UPDATE CASCADE
  - user_id → user_account(user_id) ON DELETE/UPDATE CASCADE
- Comments in db.sql for clarity

Testing done locally:
- Insert with valid property and user succeeds
- Duplicate insert fails (PK violation)
- Insert with invalid property/user fails (FK violation)
