### PR TITLE
Add property_category join table to link properties and categories

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -2,3 +2,13 @@
 CREATE DATABASE airbnb;
 -- work with airbnb database
 USE airbnb;
+
+--
+-- Table structure for table `property_category`
+--
+-- This table links properties to categories, establishing a many-to-many relationship.
+-- Each row represents a specific category assigned to a property.
+--
+-- `property_id`: Foreign key referencing the `property` table.
+-- `category_id`: Foreign key referencing the `category` table.
+--

--- a/db.sql
+++ b/db.sql
@@ -12,3 +12,8 @@ USE airbnb;
 -- `property_id`: Foreign key referencing the `property` table.
 -- `category_id`: Foreign key referencing the `category` table.
 --
+
+CREATE TABLE `property_category` (
+  `property_id` INT NOT NULL,
+  `category_id` INT NOT NULL
+);

--- a/db.sql
+++ b/db.sql
@@ -17,3 +17,10 @@ CREATE TABLE `property_category` (
   `property_id` INT NOT NULL,
   `category_id` INT NOT NULL
 );
+
+--
+-- Constraints for table `property_category`
+--
+ALTER TABLE `property_category`
+  ADD CONSTRAINT `fk_property_category_property` FOREIGN KEY (`property_id`) REFERENCES `property` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_property_category_category` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`) ON DELETE CASCADE;

--- a/db.sql
+++ b/db.sql
@@ -24,3 +24,9 @@ CREATE TABLE `property_category` (
 ALTER TABLE `property_category`
   ADD CONSTRAINT `fk_property_category_property` FOREIGN KEY (`property_id`) REFERENCES `property` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `fk_property_category_category` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`) ON DELETE CASCADE;
+
+--
+-- Primary key for table `property_category`
+--
+ALTER TABLE `property_category`
+  ADD PRIMARY KEY (`property_id`, `category_id`);

--- a/property_category.docx
+++ b/property_category.docx
@@ -1,0 +1,11 @@
+Problem Statement:
+The database needs a way to associate properties with multiple categories in a many-to-many relationship. This is necessary to allow a property to be classified under various labels, such as 'beachfront', 'pet-friendly', and 'has a pool'.
+
+Implemented Solution:
+A join table named `property_category` was created to link the `property` and `category` tables. This table has two columns, `property_id` and `category_id`, which are foreign keys referencing the respective tables. A composite primary key on (`property_id`, `category_id`) ensures that each property-category pair is unique.
+
+Why it was necessary:
+Without a join table, it would be difficult to model a many-to-many relationship between properties and categories. This solution is scalable and follows database normalization principles.
+
+Expected Outcome:
+The `property_category` table will allow the application to efficiently query all categories for a given property or all properties belonging to a specific category. This will enable features like filtering properties by category.


### PR DESCRIPTION
---
Added a property_category table to enable a many-to-many relationship between properties and categories.
---

Key Changes:

Created property_category with property_id and category_id.

Added foreign key constraints with ON DELETE CASCADE.

Defined composite primary key (property_id, category_id).

Documented table purpose in db.sql and added property_category.docx.
---

Outcome:
Provides a clean join table for linking properties to multiple categories while maintaining referential integrity.

---
---
